### PR TITLE
before_action instead of before_filter

### DIFF
--- a/lib/rosebud.rb
+++ b/lib/rosebud.rb
@@ -26,7 +26,7 @@ module Rosebud
   module ClassMethods
     def params(action = :all, &block)
       action = action.to_s
-      before_filter do
+      before_action do
         if action == 'all' || params[:action] == action
           ParamsScope.new(self, params, &block)
         end


### PR DESCRIPTION
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.