### PR TITLE
Added parameter coercion and callable default

### DIFF
--- a/lib/rosebud/params_scope.rb
+++ b/lib/rosebud/params_scope.rb
@@ -4,31 +4,41 @@ module Rosebud
       @controller = controller
       @params = params
       @declared_params = []
-      
+
       instance_eval(&block)
     end
-    
+
     def requires(name, validations = {})
       name = name.to_sym
       validations.merge!({ presence: true })
-      
+
       validate(name, @params[name], validations)
     end
-    
+
     def optional(name, options = {})
       name = name.to_sym
       if (@params[name].nil? || @params[name] == '') && options.has_key?(:default)
-        @params[name] = options.delete(:default)
+        default = options.delete(:default)
+        @params[name] = default.respond_to?(:call) ? default.call(@params, @controller) : default
       end
       validate(name, @params[name], options)
     end
-    
+
     private
     def validate(attribute, value, validations)
       validations.each do |type, options|
+        next if type == :default
+
         validator_class = Validations.validators[type]
         raise("Validator #{type} is not registered...") unless validator_class
+
         validator_class.new.validate_param(attribute, value, options)
+        if type == :type
+          coerced = Rosebud::Validations::TypeValidator.new.send(:coerce_value, options, value)
+          if coerced != value
+            @params[attribute] = coerced
+          end
+        end
       end
     end
   end

--- a/spec/optional_spec.rb
+++ b/spec/optional_spec.rb
@@ -7,6 +7,7 @@ describe Rosebud::ParamsScope do
 
       params do
         optional :name, type: Integer, default: 1234
+        optional :other, type: Integer, default: ->(_, _) { 1234 }
       end
 
       def index
@@ -32,6 +33,17 @@ describe Rosebud::ParamsScope do
     it 'should add a default value to the params' do
       get :index
       expect(controller.params[:name]).to eq(1234)
+    end
+
+    it 'should accept default value with callable' do
+      get :index
+      expect(controller.params[:other]).to eq(1234)
+    end
+
+    it 'should accept coerce value if possible' do
+      get :index, params: { other: '123' } if Rails.version > '4.2'
+      get :index, name: '123' if Rails.version < '5'
+      expect(controller.params[:other]).to eq(123)
     end
   end
 end


### PR DESCRIPTION
After using grape but going back to Rails API I was looking for a good way to document and coerce parameters and found this Gem.

I've added default with block and automatic parameter coercion to improve working with non-json fields, like Date, Datetime

```ruby
optional :from, type: DateTime, default: ->(params, controller) { Time.zone.now }
```
